### PR TITLE
Convert API functions to onRequest handlers

### DIFF
--- a/functions/api/live.js
+++ b/functions/api/live.js
@@ -1,104 +1,104 @@
-export default {
-  async fetch(req) {
-    const url = new URL(req.url);
-    const matchId = url.searchParams.get("matchId");
-    const clubId = url.searchParams.get("clubId");
+export async function onRequest(context) {
+  const { request } = context;
 
-    if (!matchId || !clubId) {
-      return new Response(JSON.stringify({ error: "Missing matchId or clubId" }), {
-        status: 400,
-        headers: { "content-type": "application/json" },
+  const url = new URL(request.url);
+  const matchId = url.searchParams.get("matchId");
+  const clubId = url.searchParams.get("clubId");
+
+  if (!matchId || !clubId) {
+    return new Response(JSON.stringify({ error: "Missing matchId or clubId" }), {
+      status: 400,
+      headers: { "content-type": "application/json" },
+    });
+  }
+
+  const target = `https://cricclubs.com/QCF/fullScorecard.do?matchId=${matchId}&clubId=${clubId}`;
+
+  try {
+    const res = await fetch(target, {
+      headers: {
+        "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64)",
+        "Accept": "text/html,application/xhtml+xml",
+        "Referer": "https://cricclubs.com/",
+      },
+    });
+
+    const html = await res.text();
+
+    // --- Extract meta description for quick score summary ---
+    const descMatch =
+      html.match(/<meta[^>]+property="og:description"[^>]+content="([^"]+)"/i) ||
+      html.match(/<meta[^>]+name="description"[^>]+content="([^"]+)"/i) ||
+      html.match(/<title>(.*?)<\/title>/i);
+
+    const desc = descMatch ? descMatch[1] : "";
+
+    // Example: Dragons 145/7 (20.0 overs) Enemy 122/9 (20.0 overs)
+    const pattern =
+      /([A-Za-z\s]+)\s(\d+\/\d+)\s*\(?([\d.]+)\s*overs?\)?\s*([A-Za-z\s]+)\s(\d+\/\d+)\s*\(?([\d.]+)\s*overs?\)?/i;
+    const m = desc.match(pattern);
+
+    let team1 = "Team A",
+      team2 = "Team B",
+      innings1 = {},
+      innings2 = {};
+
+    if (m) {
+      team1 = m[1].trim();
+      innings1 = { score: m[2], overs: m[3] };
+      team2 = m[4].trim();
+      innings2 = { score: m[5], overs: m[6] };
+    }
+
+    const battingTeam =
+      parseInt((innings2.score || "0").split("/")[0]) > 0 ? team2 : team1;
+    const bowlingTeam = battingTeam === team1 ? team2 : team1;
+    const targetScore =
+      innings1.score ? parseInt(innings1.score.split("/")[0]) + 1 : null;
+
+    // --- Extract batsmen (2 top rows) ---
+    const batsmen = [];
+    const batRegex =
+      /<td[^>]*>\s*([\w\s.'-]+)\s*<\/td>\s*<td[^>]*>(\d+)<\/td>\s*<td[^>]*>(\d+)<\/td>/g;
+    let matchBat;
+    while ((matchBat = batRegex.exec(html)) && batsmen.length < 2) {
+      batsmen.push({
+        name: matchBat[1].trim(),
+        runs: matchBat[2],
+        balls: matchBat[3],
       });
     }
 
-    const target = `https://cricclubs.com/QCF/fullScorecard.do?matchId=${matchId}&clubId=${clubId}`;
+    // --- Extract bowler (first row) ---
+    const bowlRegex =
+      /<td[^>]*>\s*([\w\s.'-]+)\s*<\/td>\s*<td[^>]*>(\d+\.\d+)<\/td>\s*<td[^>]*>(\d+)<\/td>\s*<td[^>]*>(\d+)<\/td>\s*<td[^>]*>(\d+)<\/td>/;
+    const b = html.match(bowlRegex);
+    const bowler = b
+      ? {
+          name: b[1].trim(),
+          overs: b[2],
+          runs: b[4],
+          wickets: b[5],
+        }
+      : null;
 
-    try {
-      const res = await fetch(target, {
-        headers: {
-          "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64)",
-          "Accept": "text/html,application/xhtml+xml",
-          "Referer": "https://cricclubs.com/",
-        },
-      });
-
-      const html = await res.text();
-
-      // --- Extract meta description for quick score summary ---
-      const descMatch =
-        html.match(/<meta[^>]+property="og:description"[^>]+content="([^"]+)"/i) ||
-        html.match(/<meta[^>]+name="description"[^>]+content="([^"]+)"/i) ||
-        html.match(/<title>(.*?)<\/title>/i);
-
-      const desc = descMatch ? descMatch[1] : "";
-
-      // Example: Dragons 145/7 (20.0 overs) Enemy 122/9 (20.0 overs)
-      const pattern =
-        /([A-Za-z\s]+)\s(\d+\/\d+)\s*\(?([\d.]+)\s*overs?\)?\s*([A-Za-z\s]+)\s(\d+\/\d+)\s*\(?([\d.]+)\s*overs?\)?/i;
-      const m = desc.match(pattern);
-
-      let team1 = "Team A",
-        team2 = "Team B",
-        innings1 = {},
-        innings2 = {};
-
-      if (m) {
-        team1 = m[1].trim();
-        innings1 = { score: m[2], overs: m[3] };
-        team2 = m[4].trim();
-        innings2 = { score: m[5], overs: m[6] };
-      }
-
-      const battingTeam =
-        parseInt((innings2.score || "0").split("/")[0]) > 0 ? team2 : team1;
-      const bowlingTeam = battingTeam === team1 ? team2 : team1;
-      const target =
-        innings1.score ? parseInt(innings1.score.split("/")[0]) + 1 : null;
-
-      // --- Extract batsmen (2 top rows) ---
-      const batsmen = [];
-      const batRegex =
-        /<td[^>]*>\s*([\w\s.'-]+)\s*<\/td>\s*<td[^>]*>(\d+)<\/td>\s*<td[^>]*>(\d+)<\/td>/g;
-      let matchBat;
-      while ((matchBat = batRegex.exec(html)) && batsmen.length < 2) {
-        batsmen.push({
-          name: matchBat[1].trim(),
-          runs: matchBat[2],
-          balls: matchBat[3],
-        });
-      }
-
-      // --- Extract bowler (first row) ---
-      const bowlRegex =
-        /<td[^>]*>\s*([\w\s.'-]+)\s*<\/td>\s*<td[^>]*>(\d+\.\d+)<\/td>\s*<td[^>]*>(\d+)<\/td>\s*<td[^>]*>(\d+)<\/td>\s*<td[^>]*>(\d+)<\/td>/;
-      const b = html.match(bowlRegex);
-      const bowler = b
-        ? {
-            name: b[1].trim(),
-            overs: b[2],
-            runs: b[4],
-            wickets: b[5],
-          }
-        : null;
-
-      return new Response(
-        JSON.stringify({
-          ok: true,
-          battingTeam,
-          bowlingTeam,
-          innings1,
-          innings2,
-          target,
-          batsmen,
-          bowler,
-        }),
-        { headers: { "content-type": "application/json" } }
-      );
-    } catch (e) {
-      return new Response(JSON.stringify({ error: e.message }), {
-        status: 500,
-        headers: { "content-type": "application/json" },
-      });
-    }
-  },
-};
+    return new Response(
+      JSON.stringify({
+        ok: true,
+        battingTeam,
+        bowlingTeam,
+        innings1,
+        innings2,
+        target: targetScore,
+        batsmen,
+        bowler,
+      }),
+      { headers: { "content-type": "application/json" } }
+    );
+  } catch (e) {
+    return new Response(JSON.stringify({ error: e.message }), {
+      status: 500,
+      headers: { "content-type": "application/json" },
+    });
+  }
+}

--- a/functions/api/test.js
+++ b/functions/api/test.js
@@ -1,8 +1,9 @@
-export default {
-  async fetch() {
-    return new Response(
-      JSON.stringify({ ok: true, msg: "Cloudflare Functions working!" }),
-      { headers: { "content-type": "application/json" } }
-    );
-  },
-};
+export async function onRequestGet({ request }) {
+  // Touch the incoming request object to align with Pages Function handler expectations.
+  request.headers.get("accept");
+
+  return new Response(
+    JSON.stringify({ ok: true, msg: "Cloudflare Functions working!" }),
+    { headers: { "content-type": "application/json" } }
+  );
+}


### PR DESCRIPTION
## Summary
- update the live API function to export an `onRequest` handler that uses the Pages Functions context
- update the test API function to export an `onRequestGet` handler while keeping the JSON response

## Testing
- npx wrangler deploy *(fails: npm 403 when downloading wrangler in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e173ed9360832699f2c679af2cdd27