### PR TITLE
Add scorecard-only overlay mode

### DIFF
--- a/functions/api/live.js
+++ b/functions/api/live.js
@@ -20,6 +20,87 @@ function textSnippet(value, length = 300) {
   return value.replace(/\s+/g, " ").trim().slice(0, length);
 }
 
+function decodeHtmlEntities(value = "") {
+  const named = {
+    amp: "&",
+    lt: "<",
+    gt: ">",
+    quot: '"',
+    apos: "'",
+    nbsp: " ",
+  };
+
+  return value.replace(/&(#x?[0-9a-f]+|[a-z]+);/gi, (entity, code) => {
+    const lowerCode = code.toLowerCase();
+
+    if (lowerCode[0] === "#") {
+      const base = lowerCode[1] === "x" ? 16 : 10;
+      const number = parseInt(lowerCode.slice(base === 16 ? 2 : 1), base);
+      return Number.isNaN(number) ? entity : String.fromCodePoint(number);
+    }
+
+    return named[lowerCode] || entity;
+  });
+}
+
+function stripTags(value = "") {
+  return decodeHtmlEntities(value.replace(/<[^>]+>/g, " ")).replace(/\s+/g, " ").trim();
+}
+
+function getAttribute(value = "", attributeName) {
+  const attr = new RegExp(`${attributeName}\\s*=\\s*(["'])(.*?)\\1`, "i").exec(value);
+  return attr ? decodeHtmlEntities(attr[2]) : "";
+}
+
+function parseScorecardTeams(scheduleHtml = "") {
+  const entries = [];
+  const liPattern = /<li\b([^>]*)>([\s\S]*?)<\/li>/gi;
+  let liMatch;
+
+  while ((liMatch = liPattern.exec(scheduleHtml))) {
+    const [, attributes, content] = liMatch;
+    const className = getAttribute(attributes, "class");
+    const logoMatch = content.match(/<img\b[^>]*src\s*=\s*(["'])(.*?)\1/i);
+
+    if (/\b(?:win|lose|tie)\b/i.test(className)) {
+      const teamNameMatch = content.match(/<span\b[^>]*class\s*=\s*(["'])teamName\1[^>]*>([\s\S]*?)<\/span>/i);
+      const scoreMatch = content.match(/<span\b(?![^>]*class\s*=\s*(["'])teamName\1)[^>]*>\s*([^<]*\d+\s*\/\s*\d+[^<]*)<\/span>/i);
+      const oversMatch = content.match(/<p\b[^>]*>([\s\S]*?)<\/p>/i);
+
+      entries.push({
+        type: "team",
+        resultClass: className,
+        name: teamNameMatch ? stripTags(teamNameMatch[2]) : "",
+        score: scoreMatch ? stripTags(scoreMatch[2]).replace(/\s+/g, "") : "",
+        overs: oversMatch ? stripTags(oversMatch[1]) : "",
+        logo: logoMatch ? decodeHtmlEntities(logoMatch[2]) : "",
+      });
+    } else if (logoMatch) {
+      entries.push({ type: "logo", src: decodeHtmlEntities(logoMatch[2]) });
+    } else if (/\bvs\b/i.test(className) || /\bVS\b/.test(stripTags(content))) {
+      entries.push({ type: "vs" });
+    }
+  }
+
+  const teams = entries.filter((entry) => entry.type === "team");
+
+  for (const [teamIndex, team] of teams.entries()) {
+    if (team.logo) continue;
+
+    const entryIndex = entries.indexOf(team);
+    const adjacentIndexes = teamIndex === 0
+      ? [entryIndex - 1, entryIndex + 1]
+      : [entryIndex + 1, entryIndex - 1];
+    const logoEntry = adjacentIndexes
+      .map((index) => entries[index])
+      .find((entry) => entry && entry.type === "logo");
+
+    if (logoEntry) team.logo = logoEntry.src;
+  }
+
+  return teams;
+}
+
 export async function onRequest(context) {
   const { request } = context;
 
@@ -73,43 +154,24 @@ export async function onRequest(context) {
     
     let team1 = "Team A", team2 = "Team B";
     let innings1 = {}, innings2 = {};
-    
-    if (scheduleMatch) {
-      // Pattern to match each team's complete info block
-      const winBlockPattern = /<li class="win"[^>]*>([\s\S]*?)<\/li>/g;
-      const winBlocks = [...scheduleMatch[0].matchAll(winBlockPattern)];
-      
-      if (winBlocks.length >= 1) {
-        const block1 = winBlocks[0][1];
-        const name1 = block1.match(/<span class="teamName">([^<]+)<br>/);
-        const score1 = block1.match(/<span>(\d+\/\d+)<\/span>/);
-        const overs1 = block1.match(/([\d.]+)\s*\/\d+\s*(?:ov|Overs)/i);
-        
-        if (name1) team1 = name1[1].trim();
-        if (score1) innings1.score = score1[1];
-        if (overs1) innings1.overs = overs1[1];
-      }
-      
-      if (winBlocks.length >= 2) {
-        const block2 = winBlocks[1][1];
-        const name2 = block2.match(/<span class="teamName">([^<]+)<br>/);
-        const score2 = block2.match(/<span>(\d+\/\d+)<\/span>/);
-        // Look for overs pattern like "2.3 /20 ov" (not "0/0 Overs")
-        const overs2 = block2.match(/([\d.]+)\s*\/\d+(?:\.\d+)?\s*(?:ov|overs?)/i);
-        
-        if (name2) team2 = name2[1].trim();
-        if (score2) {
-          innings2.score = score2[1];
-          // If score is 0/0, innings hasn't started
-          if (score2[1] === "0/0") {
-            innings2.overs = "0";
-          } else if (overs2) {
-            innings2.overs = overs2[1];
-          } else {
-            innings2.overs = "0";
-          }
-        }
-      }
+    const scorecardTeams = scheduleMatch ? parseScorecardTeams(scheduleMatch[0]) : [];
+
+    if (scorecardTeams.length >= 1) {
+      team1 = scorecardTeams[0].name || team1;
+      innings1 = {
+        score: scorecardTeams[0].score,
+        overs: (scorecardTeams[0].overs.match(/[\d.]+/) || [""])[0],
+      };
+    }
+
+    if (scorecardTeams.length >= 2) {
+      team2 = scorecardTeams[1].name || team2;
+      innings2 = {
+        score: scorecardTeams[1].score,
+        overs: (scorecardTeams[1].overs.match(/[\d.]+/) || ["0"])[0],
+      };
+
+      if (innings2.score === "0/0") innings2.overs = "0";
     }
 
     if (!scheduleMatch || !innings1.score) {
@@ -177,6 +239,7 @@ export async function onRequest(context) {
       bowlingTeam,
       innings1,
       innings2,
+      scorecardTeams,
       target: targetScore,
       striker,
       nonStriker,

--- a/public/index.html
+++ b/public/index.html
@@ -120,6 +120,118 @@
       animation: pulse 1.5s infinite alternate;
     }
 
+
+    .scorecard-summary {
+      display: none;
+      align-items: center;
+      justify-content: center;
+      gap: 22px;
+      margin: 0;
+      padding: 0;
+      list-style: none;
+      width: 100%;
+      text-align: center;
+    }
+
+    .scorecard-summary li {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      justify-content: center;
+      min-width: 0;
+    }
+
+    .scorecard-summary .team-logo-link {
+      display: flex;
+      align-items: center;
+      justify-content: center;
+    }
+
+    .scorecard-summary .scorecard-logo {
+      height: 72px;
+      width: 72px;
+      border-radius: 50%;
+      object-fit: cover;
+      border: 2px solid rgba(255, 215, 0, .9);
+      filter: drop-shadow(0 0 6px rgba(0, 0, 0, .65));
+    }
+
+    .scorecard-summary .teamName {
+      display: block;
+      max-width: 230px;
+      color: white;
+      font-size: 1.2em;
+      font-weight: 700;
+      line-height: 1.2;
+    }
+
+    .scorecard-summary .team-score {
+      color: gold;
+      font-size: 2.1em;
+      font-weight: 800;
+      line-height: 1.05;
+    }
+
+    .scorecard-summary .team-overs {
+      margin: 4px 0 0;
+      color: #dbe9ff;
+      font-size: .95em;
+      text-transform: lowercase;
+    }
+
+    .scorecard-summary .vs {
+      min-width: auto;
+      color: gold;
+      font-size: 1.15em;
+      font-weight: 800;
+      letter-spacing: .08em;
+    }
+
+    .scorecard-summary .win .teamName,
+    .scorecard-summary .win .team-score {
+      text-shadow: 0 0 12px rgba(255, 215, 0, .55);
+    }
+
+    body.scorecard-mode .qcf-logo,
+    body.scorecard-mode .side,
+    body.scorecard-mode .score-card {
+      display: none;
+    }
+
+    body.scorecard-mode .overlay {
+      justify-content: center;
+      align-items: center;
+      width: auto;
+      min-width: min(920px, calc(100vw - 32px));
+      padding: 14px 28px;
+      border-radius: 28px;
+      border-bottom: 3px solid gold;
+    }
+
+    body.scorecard-mode .scorecard-summary {
+      display: flex;
+    }
+
+    @media (max-width: 720px) {
+      .scorecard-summary {
+        gap: 10px;
+      }
+
+      .scorecard-summary .scorecard-logo {
+        height: 50px;
+        width: 50px;
+      }
+
+      .scorecard-summary .teamName {
+        max-width: 130px;
+        font-size: .9em;
+      }
+
+      .scorecard-summary .team-score {
+        font-size: 1.45em;
+      }
+    }
+
     @keyframes pulse {
       from { text-shadow: 0 0 5px gold; }
       to { text-shadow: 0 0 15px gold; }
@@ -195,6 +307,10 @@
       .bowling-side .player-line {
         justify-content: center;
       }
+
+      body.scorecard-mode .overlay {
+        flex-direction: row;
+      }
     }
 
     .qcf-logo {
@@ -237,6 +353,8 @@
 
   <div class="overlay-wrapper">
     <div class="overlay">
+      <ul id="scorecard-summary" class="scorecard-summary list-inline" aria-label="Scorecard summary"></ul>
+
       <div class="side batting-side">
         <div class="team-block">
           <div class="team-row">
@@ -278,6 +396,9 @@
     const clubId = query.get("clubId");
     const api = query.get("api") || window.location.origin;
     const debug = query.get("debug") === "1";
+    const scorecardOnly = query.get("scorecard") === "1" || query.get("view") === "scorecard";
+
+    if (scorecardOnly) document.body.classList.add("scorecard-mode");
 
     const debugBox = document.getElementById("debug-box");
     if (debug) debugBox.style.display = "block";
@@ -289,6 +410,65 @@
       document.getElementById("striker-info").innerHTML = "";
       document.getElementById("non-striker-info").innerHTML = "";
       document.getElementById("bowler-info").innerHTML = "";
+
+      if (scorecardOnly) {
+        document.getElementById("scorecard-summary").innerHTML = `<li>${escapeHtml(message)}</li>`;
+      }
+    }
+
+    function escapeHtml(value) {
+      return String(value ?? "").replace(/[&<>"']/g, (character) => ({
+        "&": "&amp;",
+        "<": "&lt;",
+        ">": "&gt;",
+        '"': "&quot;",
+        "'": "&#39;",
+      }[character]));
+    }
+
+    function normalizeOvers(overs) {
+      return String(overs || "").replace(/\s+/g, " ").trim();
+    }
+
+    function renderScorecardSummary(data) {
+      const teams = data.scorecardTeams || [];
+      const firstTeam = teams[0] || {
+        name: data.battingTeam || "Team A",
+        score: data.innings1?.score || "--/--",
+        overs: data.innings1?.overs ? `${data.innings1.overs} ov` : "-- ov",
+      };
+      const secondTeam = teams[1] || {
+        name: data.bowlingTeam || "Team B",
+        score: data.innings2?.score || "--/--",
+        overs: data.innings2?.overs ? `${data.innings2.overs} ov` : "-- ov",
+      };
+
+      const renderLogo = (team, fallback, alt) => {
+        const logo = team.logo || fallback;
+        return `
+          <li>
+            <span class="team-logo-link">
+              <img src="${escapeHtml(logo)}" class="scorecard-logo img-responsive img-circle" alt="${escapeHtml(alt)}">
+            </span>
+          </li>
+        `;
+      };
+
+      const renderTeam = (team) => `
+        <li class="${escapeHtml(team.resultClass || "")}">
+          <span class="teamName">${escapeHtml(team.name || "Team")}</span>
+          <span class="team-score">${escapeHtml(team.score || "--/--")}</span>
+          <p class="team-overs">${escapeHtml(normalizeOvers(team.overs) || "-- ov")}</p>
+        </li>
+      `;
+
+      document.getElementById("scorecard-summary").innerHTML = `
+        ${renderLogo(firstTeam, "enemy.png", firstTeam.name || "First team")}
+        ${renderTeam(firstTeam)}
+        <li class="vs">VS</li>
+        ${renderTeam(secondTeam)}
+        ${renderLogo(secondTeam, "dragons.png", secondTeam.name || "Second team")}
+      `;
     }
 
     async function updateOverlay() {
@@ -305,6 +485,11 @@
 
         if (debug) debugBox.innerText = JSON.stringify(data, null, 2);
         if (!res.ok || data.error) throw new Error(data.error || `API returned HTTP ${res.status}`);
+
+        if (scorecardOnly) {
+          renderScorecardSummary(data);
+          return;
+        }
 
         const parseRuns = (scoreString) => {
           if (!scoreString) return 0;


### PR DESCRIPTION
### Motivation
- Provide a way to show only the compact scorecard summary UL from a CricClubs scorecard as an overlay instead of the full batting/bowling UI.
- Make the upstream HTML parsing robust enough to extract team names, scores, overs and adjacent team logos so the compact summary can exactly mirror the original scorecard element.

### Description
- Added HTML parsing helpers (`decodeHtmlEntities`, `stripTags`, `getAttribute`, `parseScorecardTeams`) and logic in `functions/api/live.js` to extract `scorecardTeams` (team name, score, overs, result class, logo) from the `<ul class="list-inline">` schedule block and return it in the API response.
- Added a scorecard-only front-end mode in `public/index.html` enabled with `?scorecard=1` or `?view=scorecard`, which hides the regular overlay and shows a new `#scorecard-summary` `<ul>` rendered by `renderScorecardSummary`.
- Implemented CSS for the compact layout (`.scorecard-summary`, circular logos, team name/score/overs and `VS` styling) and small helpers on the client (`escapeHtml`, `normalizeOvers`) to safely render the parsed data.
- Short-circuited the overlay update flow so when scorecard mode is active the page only calls `renderScorecardSummary(data)` and does not render the full batting/bowling UI.

### Testing
- Ran `git diff --check` with no issues reported (passed).
- Syntax-checked the API file with `node --check functions/api/live.js` (passed).
- Extracted and syntax-checked the inline overlay script with `node --check /tmp/overlay-script.js` (passed).
- Mocked a CricClubs scorecard response and invoked the function via `onRequest` to assert `scorecardTeams` parsing (test performed in Node and assertions passed: "Parsed scorecard summary teams successfully").
- Attempted to use browser automation for visual verification but no browser automation was available in the environment, so no screenshot test was run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a07f2c961688326b5e462447d70aaa5)